### PR TITLE
fix: spawn g++ ENOENT

### DIFF
--- a/app/services/compiler/detector.js
+++ b/app/services/compiler/detector.js
@@ -123,6 +123,8 @@ function detectCompiler() {
     return 'g++';
 }
 
+detectCompiler();
+
 async function getCompilerVersion() {
     return new Promise((resolve) => {
         const compiler = detectedCompiler || 'g++';


### PR DESCRIPTION
do path của g++ k được set nên máy nào k cài ở global path sẽ lỗi spawn

closed #4 